### PR TITLE
Change baseurl to one that is usable

### DIFF
--- a/mozwebqa.cfg
+++ b/mozwebqa.cfg
@@ -1,4 +1,4 @@
 [DEFAULT]
 api = webdriver
-baseurl = https://wiki.allizom.org
+baseurl = https://wiki.mozilla.org
 tags = wiki


### PR DESCRIPTION
The baseurl in mozwebqa.cfg points to https://wiki.allizom.org, but we cannot run tests on that because of authentication. All our tests actually run against prod, so I am updating the cfg file to also point to https://wiki.mozilla.org.
