### PR TITLE
Remove pytest-xdist from project requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ execnet==1.0.9
 py==1.4.9
 pytest==2.2.4
 pytest-mozwebqa==1.0
-pytest-xdist==1.8
 rdflib==3.1.0
 selenium
 requests==0.11.2


### PR DESCRIPTION
This works in conjunction with the infrastructure-requirements repo that I discussed in an email to mozwebqa.  
