### PR TITLE
Use implicit instead of explicit wait

### DIFF
--- a/pages/log_in_or_create_account.py
+++ b/pages/log_in_or_create_account.py
@@ -85,7 +85,7 @@ class LogInOrCreateAccountPage(BasePage):
 
     @property
     def is_error_message_present(self):
-        return self.is_element_present(*self._create_account_error_box_locator)
+        return self.is_element_visible(self._create_account_error_box_locator)
 
     @property
     def get_error_message_text(self):

--- a/tests/test_create_user.py
+++ b/tests/test_create_user.py
@@ -40,7 +40,6 @@ class TestCreateUser:
         create_account_pg.click_create_account_link()
         create_account_pg.create_user(mock_user['username'], mock_user['password'],
                                       'blah', mock_user['email'], mock_user['realname'])
-        create_account_pg.wait_for_page_to_load()
         Assert.true(create_account_pg.is_error_message_present)
         Assert.true(create_account_pg.get_error_message_text.index('The passwords you entered do not match.'))
 


### PR DESCRIPTION
The wait that was added previously is actually needed in a number of tests, so I addressed that by utilizing an implicit wait for the element that we need to assert on. Also, it looked like the previous wait might not actually have been doing what was needed, as it was waiting for an element that is present on every page.
