### PR TITLE
Change expected page title as new version of MediaWiki doesn't display the name for the home page

### DIFF
--- a/pages/watch_page.py
+++ b/pages/watch_page.py
@@ -11,10 +11,10 @@ from base import BasePage
 
 class WatchPage(BasePage):
 
-    _page_title = 'Main Page - MozillaWiki'
+    _page_title = 'MozillaWiki'
 
     _return_to_page_locator = (By.CSS_SELECTOR, '#n-mainpage-description > a')
-    _watchlist_message_locator = (By.CSS_SELECTOR, '#mw-content-text > p')
+    _watchlist_message_locator = (By.CSS_SELECTOR, 'div.mw-js-message-ajaxwatch > p')
 
     @property
     def return_to_page_visible(self):


### PR DESCRIPTION
Also update locator for watched message
