### PR TITLE
Xfail test_visitor_can_watch_page because of Bug 1049082 - Page markup for the watch notification message differs between dev and staging/prod

### DIFF
--- a/tests/test_watch_main_page_after_log_in.py
+++ b/tests/test_watch_main_page_after_log_in.py
@@ -14,6 +14,8 @@ from pages.log_in_or_create_account import LogInOrCreateAccountPage
 class TestWatchPage:
 
     @pytest.mark.nondestructive
+    @pytest.mark.xfail("'-dev' in config.getvalue('base_url')",
+                       reason='Bug 1049082 - Page markup for the watch notification message differs between dev and staging/prod')
     def test_visitor_can_watch_page(self, mozwebqa):
         home_pg = HomePage(mozwebqa)
         home_pg.go_to_home_page()


### PR DESCRIPTION
I have opened the above bug to inquire about how to address the difference. If the difference is to persist for some time we may need separate code paths for dev and stage/prod, but I think that should be avoided. Xfailing for now to allow the build to pass again.
