### PR TITLE
Fixing failing test_watch_main_page_after_log_in.py

### DIFF
--- a/page.py
+++ b/page.py
@@ -6,6 +6,7 @@
 
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.common.action_chains import ActionChains
 from unittestzero import Assert
 
 
@@ -40,3 +41,8 @@ class Page(object):
             return False
         finally:
             self.selenium.implicitly_wait(self.testsetup.default_implicit_wait)
+
+    def mouse_over(self, *locator):
+        actions_dropdown_element = self.selenium.find_element(*locator)
+        mouse_over = ActionChains(self.selenium).move_to_element(actions_dropdown_element)
+        mouse_over.perform()

--- a/pages/header_region.py
+++ b/pages/header_region.py
@@ -17,6 +17,7 @@ class HeaderRegion(Page):
     _view_source_locator = (By.CSS_SELECTOR, '#ca-viewsource a')
     _edit_locator = (By.CSS_SELECTOR, '#ca-edit a')
     _history_locator = (By.CSS_SELECTOR, '#ca-history a')
+    _actions_locator = (By.ID, 'p-cactions')
     _watch_locator = (By.CSS_SELECTOR, '#ca-watch a')
     _unwatch_locator = (By.CSS_SELECTOR, '#ca-unwatch a')
     _refresh_locator = (By.CSS_SELECTOR, '#ca-watch a')
@@ -56,6 +57,9 @@ class HeaderRegion(Page):
         self.selenium.find_element(*self._edit_locator).click()
         from edit_wiki import EditWiki
         return EditWiki(self.testsetup)
+
+    def mouse_over_actions_dropdown(self):
+        return self.mouse_over(*self._actions_locator)
 
     @property
     def is_watch_visible(self):

--- a/pages/watch_page.py
+++ b/pages/watch_page.py
@@ -14,7 +14,7 @@ class WatchPage(BasePage):
     _page_title = 'MozillaWiki'
 
     _return_to_page_locator = (By.CSS_SELECTOR, '#n-mainpage-description > a')
-    _watchlist_message_locator = (By.CSS_SELECTOR, 'div.mw-js-message-ajaxwatch > p')
+    _watchlist_message_locator = (By.CSS_SELECTOR, '.mw-js-message-ajaxwatch p')
 
     @property
     def return_to_page_visible(self):

--- a/tests/test_watch_main_page_after_log_in.py
+++ b/tests/test_watch_main_page_after_log_in.py
@@ -26,17 +26,21 @@ class TestWatchPage:
         Assert.true(home_pg.personal_tools_region.is_log_out_visible)
 
         # Make sure page is not currently watched
+        home_pg.header_region.mouse_over_actions_dropdown()
         if home_pg.header_region.is_unwatch_visible:
             home_pg.header_region.click_unwatch()
             home_pg.go_to_home_page()
+        home_pg.header_region.mouse_over_actions_dropdown()
         Assert.true(home_pg.header_region.is_watch_visible)
 
         watch_pg = home_pg.header_region.click_watch()
         Assert.true(watch_pg.is_the_current_page)
         Assert.contains('The page "Main Page" has been added to your watchlist.', watch_pg.watchlist_message)
         watch_pg.click_return_to_page()
+        home_pg.header_region.mouse_over_actions_dropdown()
         Assert.true(home_pg.header_region.is_unwatch_visible)
         unwatch_pg = home_pg.header_region.click_unwatch()
         Assert.equal('The page "Main Page" has been removed from your watchlist.', unwatch_pg.watchlist_message)
         unwatch_pg.click_return_to_page()
+        home_pg.header_region.mouse_over_actions_dropdown()
         Assert.true(home_pg.header_region.is_watch_visible)


### PR DESCRIPTION
With new wiki layout, watch and un-watch appear in a drop down so need to mouse over to interact with them.
