### PR TITLE
Removing xfail from Search Results tests

### DIFF
--- a/pages/header_region.py
+++ b/pages/header_region.py
@@ -22,7 +22,7 @@ class HeaderRegion(Page):
     _unwatch_locator = (By.CSS_SELECTOR, '#ca-unwatch a')
     _refresh_locator = (By.CSS_SELECTOR, '#ca-watch a')
     _search_field_locator = (By.ID, 'searchInput')
-    _search_button_locator = (By.ID, 'mw-searchButton')
+    _search_button_locator = (By.ID, 'searchButton')
 
     @property
     def is_main_page_visible(self):

--- a/tests/test_search_results.py
+++ b/tests/test_search_results.py
@@ -14,7 +14,6 @@ from pages.search_results import SearchResultsPage
 class TestSearchPage:
 
     @pytest.mark.nondestructive
-    @pytest.mark.xfail(reason='Bug 1058726 - Search button ID differs between dev and staging/prod')
     def test_no_results_returned_from_blank_search(self, mozwebqa):
         home_pg = HomePage(mozwebqa)
         home_pg.go_to_home_page()
@@ -27,7 +26,6 @@ class TestSearchPage:
         Assert.equal(search_results_pg.main_search_box_text, "", "Main Search field should be empty.")
 
     @pytest.mark.nondestructive
-    @pytest.mark.xfail(reason='Bug 1058726 - Search button ID differs between dev and staging/prod')
     def test_search_term_returned_and_matched(self, mozwebqa):
         home_pg = HomePage(mozwebqa)
         home_pg.go_to_home_page()


### PR DESCRIPTION
As bug 1058726 no longer appears to be an issue.
Also, updated the locator for the search button as this had changed as well.
