### PR TITLE
#73 - removing dependency for pytest-mozwebq...

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ UnittestZero
 execnet==1.0.9
 py==1.4.9
 pytest==2.2.4
-pytest-mozwebqa==1.3
+pytest-mozwebqa
 rdflib==3.1.0
 selenium
 requests==2.4.3


### PR DESCRIPTION
from the wiki-tests requirements file to allow always picking up the latest.
